### PR TITLE
fix: changed from terracli -> terrad

### DIFF
--- a/content/docs/howto/query.md
+++ b/content/docs/howto/query.md
@@ -9,12 +9,12 @@ bookFlatSection: true
 
 - Command line
 ```bash
-terracli query wasm contract-store <contract_address> '<JSON_formed_message>'
+terrad query wasm contract-store <contract_address> '<JSON_formed_message>'
 ```
 ex)
 
 ```bash
-terracli query wasm contract-store terra18vd8fpwxzck93qlwghaj6arh4p7c5n896xzem5 '{"balance":{"address": "terra1wxe503thjmapngtnyqarxrc4jy80vf800vf0cy"}}'
+terrad query wasm contract-store terra18vd8fpwxzck93qlwghaj6arh4p7c5n896xzem5 '{"balance":{"address": "terra1wxe503thjmapngtnyqarxrc4jy80vf800vf0cy"}}'
 ```
 
 - RESTFul API

--- a/content/docs/howto/swap.md
+++ b/content/docs/howto/swap.md
@@ -22,7 +22,7 @@ Therefore, a different pricing approach is used in Terraswap - algorithmic prici
 By command line, all transactions can be executed in this way:
 
 ```bash
-terracli tx wasm execute <contract-address> <handle-msg> <coins>
+terrad tx wasm execute <contract-address> <handle-msg> <coins>
 ```
 
 - `contract-address`: In swap transaction, this should be the pair address.
@@ -98,7 +98,7 @@ Swapping contract-minted token to native token is executed with the same logic a
 The method is a little bit tricky. Please do not lose your concentration!
 
 ```bash
-terracli tx wasm execute <contract-address> <handle-msg> <coins>
+terrad tx wasm execute <contract-address> <handle-msg> <coins>
 ```
 
 In the CLI, 

--- a/content/docs/howto/token.md
+++ b/content/docs/howto/token.md
@@ -53,14 +53,14 @@ You may instantiate your own token using the JSON as follows:
 Then, the CLI reads:
 
 ```bash
-terracli tx wasm instantiate <token_bin_code> '{"name": "yout_token_name", "symbol": "SYMBOL", "decimals": 3, ... }' --from your_key
+terrad tx wasm instantiate <token_bin_code> '{"name": "yout_token_name", "symbol": "SYMBOL", "decimals": 3, ... }' --from your_key
 ```
 
 After confirmantion, your token is minted on terra network!
 
 With your tx hash, you may query the tx:
 ```bash
-terracli query tx EF2REFAWE234A2EFV....
+terrad query tx EF2REFAWE234A2EFV....
 ```
 
 Then, you may find the address of your contract from:


### PR DESCRIPTION
As `terracli` was merged into `terrad`, the docs changed into `terrad`