### PR TITLE
Be more clear to represent Base64 encoding

### DIFF
--- a/content/docs/howto/swap.md
+++ b/content/docs/howto/swap.md
@@ -67,7 +67,7 @@ Swapping contract-minted token to native token is executed with the same logic a
     "send": {
         "contract": "<HumanAddr>",
         "amount": "10",
-        "msg": Binary({
+        "msg": Base64({
             "swap": {}
         })
     }

--- a/content/docs/reference/pair.md
+++ b/content/docs/reference/pair.md
@@ -45,7 +45,7 @@ Asset can be both of contract-based token and native token. It can be distinguis
 
 Swap between the given two tokens. It can be thought of as trade.<br />
 `offer_asset` is your source asset and `to` is your destination token contract.<br />
-`Binary()` means that this JSON message should be encoded into Base64.<br />
+`Base64()` means that this JSON message should be encoded into Base64.<br />
 
 
 ```json
@@ -71,7 +71,7 @@ Swap between the given two tokens. It can be thought of as trade.<br />
     "send": {
         "contract": "<HumanAddr>",
         "amount": "10",
-        "msg": Binary({
+        "msg": Base64({
             "swap": {
                 "offer_asset": {
                     "info" : {

--- a/content/docs/reference/router.md
+++ b/content/docs/reference/router.md
@@ -45,14 +45,14 @@ Case 1) The first source token is a native token (KRT => UST => mABNB)<br />
 
 Case 2) The first source token is a CW20 token (ANC => UST => KRT)<br />
 
-Note: `Binary()` means that this JSON message should be encoded into Base64.<br />
+Note: `Base64()` means that this JSON message should be encoded into Base64.<br />
 
 ```json
 {
   "send": {
     "amount": "100000000",
     "contract": "terra14z80rwpd0alzj4xdtgqdmcqt9wd9xj5ffd60wp",
-    "msg": Binary({
+    "msg": Base64({
         "execute_swap_operations":{
             "operations":[
                 {
@@ -212,14 +212,14 @@ Case 1) The first source token is a native token (Luna => DELIGHT => TNT)<br />
 
 Case 2) The first source token is a CW20 token (DELIGHT => Luna => TNT)<br />
 
-Note: `Binary()` means that this JSON message should be encoded into Base64.<br />
+Note: `Base64()` means that this JSON message should be encoded into Base64.<br />
 
 ```json
 {
   "send": {
     "amount": "100000000",
     "contract": "terra1cl0kw9axzpzkw58snj6cy0hfp0xp8xh9tudpw2exvzuupn3fafwqqhjc24",
-    "msg": Binary({
+    "msg": Base64({
         "execute_swap_operations":{
             "operations":[
                 {


### PR DESCRIPTION
Cosmwasm type `Binary` seems not to be clear.
Changed representation as `Base64` only for docs